### PR TITLE
second batch of fixes

### DIFF
--- a/NouveauSite/assets/css/main.css
+++ b/NouveauSite/assets/css/main.css
@@ -18,8 +18,11 @@ body {
   font-weight: normal;
   font-style: normal;
   color: #191919;
-  overflow-x: hidden;
   background-color: #000000;
+}
+
+html, body{
+  overflow-x: hidden;
 }
 
 ::-webkit-scrollbar {

--- a/NouveauSite/assets/img/logo/logo-2.svg
+++ b/NouveauSite/assets/img/logo/logo-2.svg
@@ -1,15 +1,95 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="92px" height="38px" viewBox="0 0 92 38" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 58 (84663) - https://sketch.com -->
-    <title>Artboard Copy</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Artboard-Copy" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Group-2" transform="translate(0.000000, 2.000000)">
-            <text id="Ohlga." font-family="Montserrat-Bold, Montserrat" font-size="25.8048" font-weight="bold" letter-spacing="0.300055814">
-                <tspan x="0.133785604" y="25" fill="#000000">Ohlga</tspan>
-                <tspan x="82.9965991" y="25" font-size="29.4912" letter-spacing="0.342920923" fill="#17FFCA">.</tspan>
-            </text>
-            <rect id="Rectangle" stroke-opacity="0" stroke="#979797" stroke-width="0.8" x="16.4" y="0.4" width="8.8" height="9.6"></rect>
-        </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="92px"
+   height="38px"
+   viewBox="0 0 92 38"
+   version="1.1"
+   id="svg167"
+   sodipodi:docname="logo-2.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata173">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs171" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1867"
+     inkscape:window-height="1015"
+     id="namedview169"
+     showgrid="false"
+     inkscape:zoom="14.173913"
+     inkscape:cx="46"
+     inkscape:cy="19"
+     inkscape:window-x="53"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg167" />
+  <!-- Generator: Sketch 58 (84663) - https://sketch.com -->
+  <title
+     id="title156">Artboard Copy</title>
+  <desc
+     id="desc158">Created with Sketch.</desc>
+  <g
+     id="Artboard-Copy"
+     stroke="none"
+     stroke-width="1"
+     fill="none"
+     fill-rule="evenodd">
+    <g
+       id="Group-2"
+       transform="translate(0.000000, 2.000000)">
+      <g
+         aria-label="Ohlga"
+         id="Ohlga."
+         style="font-weight:bold;font-size:25.8048px;font-family:Montserrat-Bold, Montserrat;letter-spacing:0.300056">
+        <path
+           d="m 11.095786,9.3634 q -2.2176004,0 -3.4398004,1.638 -1.2222,1.638 -1.2222,4.6116 0,2.961 1.2222,4.599 1.2222,1.638 3.4398004,1.638 2.2302,0 3.4524,-1.638 1.2222,-1.638 1.2222,-4.599 0,-2.9736 -1.2222,-4.6116 -1.2222,-1.638 -3.4524,-1.638 z m 0,-3.5154 q 4.536,0 7.1064,2.5956 2.5704,2.5956 2.5704,7.1694 0,4.5612 -2.5704,7.1568 -2.5704,2.5956 -7.1064,2.5956 -4.5234004,0 -7.1064004,-2.5956 -2.5704,-2.5956 -2.5704,-7.1568 0,-4.5738 2.5704,-7.1694 2.583,-2.5956 7.1064004,-2.5956 z"
+           style="fill:#000000"
+           id="path175" />
+        <path
+           d="M 38.725242,16.4068 V 25 h -4.536 V 23.6014 18.448 q 0,-1.8522 -0.0882,-2.5452 -0.0756,-0.693 -0.2772,-1.0206 -0.2646,-0.441 -0.7182,-0.6804 -0.4536,-0.252 -1.0332,-0.252 -1.4112,0 -2.2176,1.0962 -0.8064,1.0836 -0.8064,3.0114 V 25 h -4.5108 V 5.3944 h 4.5108 v 7.56 q 1.0206,-1.2348 2.1672,-1.8144 1.1466,-0.5922 2.5326,-0.5922 2.4444,0 3.7044,1.4994 1.2726,1.4994 1.2726,4.3596 z"
+           style="fill:#000000"
+           id="path177" />
+        <path
+           d="m 43.208498,5.3944 h 4.5108 V 25 h -4.5108 z"
+           style="fill:#000000"
+           id="path179" />
+        <path
+           d="m 61.954951,22.606 q -0.9324,1.2348 -2.0538,1.8144 -1.1214,0.5796 -2.5956,0.5796 -2.583,0 -4.2714,-2.0286 -1.688401,-2.0412 -1.688401,-5.1912 0,-3.1626 1.688401,-5.1786 1.6884,-2.0286 4.2714,-2.0286 1.4742,0 2.5956,0.5796 1.1214,0.5796 2.0538,1.827 V 10.888 h 4.536 v 12.6882 q 0,3.402 -2.1546,5.1912 -2.142,1.8018 -6.2244,1.8018 -1.323,0 -2.5578,-0.2016 -1.2348,-0.2016 -2.4822,-0.6174 v -3.5154 q 1.1844,0.6804 2.3184,1.008 1.134,0.3402 2.2806,0.3402 2.2176,0 3.2508,-0.9702 1.0332,-0.9702 1.0332,-3.0366 z m -2.9736,-8.7822 q -1.3986,0 -2.1798,1.0332 -0.7812,1.0332 -0.7812,2.9232 0,1.9404 0.756,2.9484 0.756,0.9954 2.205,0.9954 1.4112,0 2.1924,-1.0332 0.7812,-1.0332 0.7812,-2.9106 0,-1.89 -0.7812,-2.9232 -0.7812,-1.0332 -2.1924,-1.0332 z"
+           style="fill:#000000"
+           id="path181" />
+        <path
+           d="m 77.45061,18.6496 q -1.4112,0 -2.1294,0.4788 -0.7056,0.4788 -0.7056,1.4112 0,0.8568 0.567,1.3482 0.5796,0.4788 1.6002,0.4788 1.2726,0 2.142,-0.9072 0.8694,-0.9198 0.8694,-2.2932 v -0.5166 z m 6.8922,-1.701 V 25 h -4.5486 v -2.0916 q -0.9072,1.2852 -2.0412,1.8774 -1.134,0.5796 -2.7594,0.5796 -2.1924,0 -3.5658,-1.2726 -1.3608,-1.2852 -1.3608,-3.3264 0,-2.4822 1.701,-3.6414 1.7136,-1.1592 5.3676,-1.1592 h 2.6586 V 15.613 q 0,-1.071 -0.8442,-1.5624 -0.8442,-0.504 -2.6334,-0.504 -1.449,0 -2.6964,0.2898 -1.2474,0.2898 -2.3184,0.8694 V 11.266 q 1.449,-0.3528 2.9106,-0.5292 1.4616,-0.189 2.9232,-0.189 3.8178,0 5.5062,1.512 1.701,1.4994 1.701,4.8888 z"
+           style="fill:#000000"
+           id="path183" />
+      </g>
+      <path
+         id="circle163"
+         style="fill:#17ffca"
+         d="m 91.5,22.299999 a 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 3,3 0 0 1 3,3 z" />
     </g>
+  </g>
 </svg>

--- a/NouveauSite/assets/img/logo/logo.svg
+++ b/NouveauSite/assets/img/logo/logo.svg
@@ -1,15 +1,95 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="92px" height="38px" viewBox="0 0 92 38" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 58 (84663) - https://sketch.com -->
-    <title>Artboard</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Artboard" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Group-2" transform="translate(0.000000, 2.000000)">
-            <text id="Ohlga." font-family="Montserrat-Bold, Montserrat" font-size="25.8048" font-weight="bold" letter-spacing="0.300055814">
-                <tspan x="0.133785604" y="25" fill="#FFFFFF">Ohlga</tspan>
-                <tspan x="82.9965991" y="25" font-size="29.4912" letter-spacing="0.342920923" fill="#17FFCA">.</tspan>
-            </text>
-            <rect id="Rectangle" stroke-opacity="0" stroke="#979797" stroke-width="0.8" x="16.4" y="0.4" width="8.8" height="9.6"></rect>
-        </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="92px"
+   height="38px"
+   viewBox="0 0 92 38"
+   version="1.1"
+   id="svg148"
+   sodipodi:docname="logo.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <metadata
+     id="metadata154">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs152" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1867"
+     inkscape:window-height="1015"
+     id="namedview150"
+     showgrid="false"
+     inkscape:zoom="18.130435"
+     inkscape:cx="46"
+     inkscape:cy="19"
+     inkscape:window-x="53"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg148" />
+  <!-- Generator: Sketch 58 (84663) - https://sketch.com -->
+  <title
+     id="title137">Artboard</title>
+  <desc
+     id="desc139">Created with Sketch.</desc>
+  <g
+     id="Artboard"
+     stroke="none"
+     stroke-width="1"
+     fill="none"
+     fill-rule="evenodd">
+    <g
+       id="Group-2"
+       transform="translate(0.000000, 2.000000)">
+      <g
+         aria-label="Ohlga"
+         id="Ohlga."
+         style="font-weight:bold;font-size:25.8048px;font-family:Montserrat-Bold, Montserrat, sans-serif;letter-spacing:0.300056">
+        <path
+           d="m 11.095786,9.3634 q -2.2176004,0 -3.4398004,1.638 -1.2222,1.638 -1.2222,4.6116 0,2.961 1.2222,4.599 1.2222,1.638 3.4398004,1.638 2.2302,0 3.4524,-1.638 1.2222,-1.638 1.2222,-4.599 0,-2.9736 -1.2222,-4.6116 -1.2222,-1.638 -3.4524,-1.638 z m 0,-3.5154 q 4.536,0 7.1064,2.5956 2.5704,2.5956 2.5704,7.1694 0,4.5612 -2.5704,7.1568 -2.5704,2.5956 -7.1064,2.5956 -4.5234004,0 -7.1064004,-2.5956 -2.5704,-2.5956 -2.5704,-7.1568 0,-4.5738 2.5704,-7.1694 2.583,-2.5956 7.1064004,-2.5956 z"
+           style="fill:#ffffff"
+           id="path187" />
+        <path
+           d="M 38.725242,16.4068 V 25 h -4.536 V 23.6014 18.448 q 0,-1.8522 -0.0882,-2.5452 -0.0756,-0.693 -0.2772,-1.0206 -0.2646,-0.441 -0.7182,-0.6804 -0.4536,-0.252 -1.0332,-0.252 -1.4112,0 -2.2176,1.0962 -0.8064,1.0836 -0.8064,3.0114 V 25 h -4.5108 V 5.3944 h 4.5108 v 7.56 q 1.0206,-1.2348 2.1672,-1.8144 1.1466,-0.5922 2.5326,-0.5922 2.4444,0 3.7044,1.4994 1.2726,1.4994 1.2726,4.3596 z"
+           style="fill:#ffffff"
+           id="path189" />
+        <path
+           d="m 43.208498,5.3944 h 4.5108 V 25 h -4.5108 z"
+           style="fill:#ffffff"
+           id="path191" />
+        <path
+           d="m 61.954951,22.606 q -0.9324,1.2348 -2.0538,1.8144 -1.1214,0.5796 -2.5956,0.5796 -2.583,0 -4.2714,-2.0286 -1.688401,-2.0412 -1.688401,-5.1912 0,-3.1626 1.688401,-5.1786 1.6884,-2.0286 4.2714,-2.0286 1.4742,0 2.5956,0.5796 1.1214,0.5796 2.0538,1.827 V 10.888 h 4.536 v 12.6882 q 0,3.402 -2.1546,5.1912 -2.142,1.8018 -6.2244,1.8018 -1.323,0 -2.5578,-0.2016 -1.2348,-0.2016 -2.4822,-0.6174 v -3.5154 q 1.1844,0.6804 2.3184,1.008 1.134,0.3402 2.2806,0.3402 2.2176,0 3.2508,-0.9702 1.0332,-0.9702 1.0332,-3.0366 z m -2.9736,-8.7822 q -1.3986,0 -2.1798,1.0332 -0.7812,1.0332 -0.7812,2.9232 0,1.9404 0.756,2.9484 0.756,0.9954 2.205,0.9954 1.4112,0 2.1924,-1.0332 0.7812,-1.0332 0.7812,-2.9106 0,-1.89 -0.7812,-2.9232 -0.7812,-1.0332 -2.1924,-1.0332 z"
+           style="fill:#ffffff"
+           id="path193" />
+        <path
+           d="m 77.45061,18.6496 q -1.4112,0 -2.1294,0.4788 -0.7056,0.4788 -0.7056,1.4112 0,0.8568 0.567,1.3482 0.5796,0.4788 1.6002,0.4788 1.2726,0 2.142,-0.9072 0.8694,-0.9198 0.8694,-2.2932 v -0.5166 z m 6.8922,-1.701 V 25 h -4.5486 v -2.0916 q -0.9072,1.2852 -2.0412,1.8774 -1.134,0.5796 -2.7594,0.5796 -2.1924,0 -3.5658,-1.2726 -1.3608,-1.2852 -1.3608,-3.3264 0,-2.4822 1.701,-3.6414 1.7136,-1.1592 5.3676,-1.1592 h 2.6586 V 15.613 q 0,-1.071 -0.8442,-1.5624 -0.8442,-0.504 -2.6334,-0.504 -1.449,0 -2.6964,0.2898 -1.2474,0.2898 -2.3184,0.8694 V 11.266 q 1.449,-0.3528 2.9106,-0.5292 1.4616,-0.189 2.9232,-0.189 3.8178,0 5.5062,1.512 1.701,1.4994 1.701,4.8888 z"
+           style="fill:#ffffff"
+           id="path195" />
+      </g>
+      <path
+         id="circle144"
+         style="fill:#17ffca"
+         d="m 91.5,22.299999 a 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 3,3 0 0 1 3,3 z" />
     </g>
+  </g>
 </svg>

--- a/NouveauSite/assets/js/main.js
+++ b/NouveauSite/assets/js/main.js
@@ -48,7 +48,11 @@ function onScroll(event) {
 		var val = currLink.getAttribute('href');
 		var refElement = document.querySelector(val);
 		var scrollTopMinus = scrollPos + 73;
-		if (refElement.offsetTop <= scrollTopMinus && (refElement.offsetTop + refElement.offsetHeight > scrollTopMinus)) {
+		if (
+			refElement
+			&& refElement.offsetTop <= scrollTopMinus
+			&& (refElement.offsetTop + refElement.offsetHeight > scrollTopMinus)
+		) {
 			document.querySelector('.page-scroll').classList.remove('active');
 			currLink.classList.add('active');
 		} else {


### PR DESCRIPTION
- logo problem: using \<text\> element in the svg file is unreliable, I converted everything to path, the logo.svg are no longer human-readable but will always perform the same across devices and browsers
- horizontal scrolling : for some reason on chrome mobile you need to apply `overflow-x : hidden` to both the body **and** html element
- errors in console when scrolling : the code was meant to interact with link pointing to elements of the page and not pointing to other pages. Now the code should do nothing if it finds a link pointing to another page instead of an id.